### PR TITLE
Fixes `TypeError` in `bot.py`

### DIFF
--- a/twitchio/ext/commands/bot.py
+++ b/twitchio/ext/commands/bot.py
@@ -127,7 +127,7 @@ class Bot(Client):
         )  # The only reason we're even creating this is to avoid attribute errors
         self._events = {}
         self._waiting = []
-        self._modules = []
+        self._modules = {}
         self._prefix = prefix
         self._cogs = {}
         self._commands = {}


### PR DESCRIPTION
Currently using this will TypeError as the parameter (`self._modules`) is initialised as a list, not a dict as needed.

<!-- Please fill this out to the best of your abilities, it makes our jobs easier -->

## Pull request summary

<!-- Tell us about this PR. What is it solving/adding? Why? Are you fixing something? -->


## Checklist
<!-- Borrowed from discord.py -->
<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
    - [ ] I have updated the changelog with a quick recap of my changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)